### PR TITLE
Fix (probably) typo in R2 function

### DIFF
--- a/R/others_batch_check.R
+++ b/R/others_batch_check.R
@@ -1457,7 +1457,6 @@ R2 <- function(poi,V,poiType,pval = T) {
       }
     }
   }
-  cr
   for (ipoi in 1:l){
     if (pval){
       pv[ipoi] <- min(pv_tmp[,ipoi])


### PR DESCRIPTION
PerformBatchCorrection breaks with error:
`Error in R2(ref, B, refType, pval = T) : object 'cr' not found.`